### PR TITLE
AUS 3517: Clicking on the map was failing to show a popup message box

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ In the project that uses the library (e.g. AuScope-Portal-UI or ngvl):
 
 This creates a symbolic link for node_modules/portal-core-ui that links to the distribution folder of the library project.
 
-Don't forget to unlink when you're no lomger interested in using the development version of the library:
+If you get an obscure 'Unhandled Promise rejection' error you may have to add:
+
+`"preserveSymlinks": true`
+
+to the 'projects'.$name.'architect'.'build'.'options' section in your 'angular.json' file in the project that uses the library.
+
+Don't forget to unlink when you're no longer interested in using the development version of the library:
 
 `npm unlink portal-core-ui`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-core-ui-app",
-  "version": "0.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-core-ui-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/portal-core-ui/package.json
+++ b/projects/portal-core-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-core-ui",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license" : "(LGPL OR Apache-2.0)",
   "repository": {
     "type" : "git",

--- a/projects/portal-core-ui/src/lib/service/openlayermap/ol-map.service.ts
+++ b/projects/portal-core-ui/src/lib/service/openlayermap/ol-map.service.ts
@@ -77,7 +77,7 @@ export class OlMapService {
                              continue;
                            }
                            const bbox = activeLayer.onlineResource.geographicElements[0];
-                           const poly = bboxPolygon([bbox.eastBoundLongitude, bbox.southBoundLatitude, bbox.westBoundLongitude, bbox.northBoundLatitude]);
+                           const poly = bboxPolygon([bbox.westBoundLongitude, bbox.southBoundLatitude, bbox.eastBoundLongitude, bbox.northBoundLatitude]);
                            if (booleanPointInPolygon(clickPoint, poly) && !clickedLayerList.includes(activeLayer)) {
                              // Add to list of clicked layers
                              clickedLayerList.push(activeLayer);

--- a/projects/portal-core-ui/src/lib/service/wms/query-wms.service.ts
+++ b/projects/portal-core-ui/src/lib/service/wms/query-wms.service.ts
@@ -65,7 +65,6 @@ export class QueryWMSService {
   * @return Observable the observable from the http request
    */
   public getFeatureInfo(onlineResource: OnlineResourceModel, sldBody: string, pixel: string[], clickCoord: any[]): Observable<any> {
-    console.log('onlineResource = ', onlineResource);
     let formdata = new HttpParams();
     formdata = formdata.append('serviceUrl', UtilitiesService.rmParamURL(onlineResource.url));
     formdata = formdata.append('lat', clickCoord[1]);


### PR DESCRIPTION
Remove message which creates clutter in browser console
Clicking on the map was failing to show a popup message box
Update version
Added extra hint to README to avoid an error which can be caused by 'npm link'