### PR TITLE
AUS-3548: WMS custom layers won't load with cesium

### DIFF
--- a/projects/portal-core-ui/src/lib/service/cesium-map/cs-map.service.ts
+++ b/projects/portal-core-ui/src/lib/service/cesium-map/cs-map.service.ts
@@ -173,6 +173,10 @@ export class CsMapService {
    * @param layer the layer to add to the map
    */
   public addLayer(layer: LayerModel, param: any): void {
+    // initiate csLayers to prevent undefined errors
+    if (!layer.csLayers) {
+       layer.csLayers = [];
+    }
 
     // Add a CSW layer to map
     if (this.conf.cswrenderer && this.conf.cswrenderer.includes(layer.id)) {


### PR DESCRIPTION
WMS custom layers won't load because of "undefined" errors due to layer.csLayers being uninitiated.
After fixing this, clicking on the pixels don't work, but I think this is due to the click handler (AUS-3528), which is still in progress.
