### PR TITLE
AUS-3589 Can't re-add WMS layer to map (problem updating fliters)

### DIFF
--- a/projects/portal-core-ui/src/lib/service/cesium-map/cs-map.service.ts
+++ b/projects/portal-core-ui/src/lib/service/cesium-map/cs-map.service.ts
@@ -249,7 +249,6 @@ export class CsMapService {
        layer.csLayers = [];
     }
     this.csMapObject.removeLayerById(layer.id);
-    delete this.layerModelList[layer.id];
     // Add a CSW layer to map
     if (this.conf.cswrenderer && this.conf.cswrenderer.includes(layer.id)) {
       // Remove old existing layer


### PR DESCRIPTION
Fixed bug where layer was being removed from layer list too soon causing the layer to not be removed from the map before it was re-added.

Can test by:

* Re-adding layer to map multiple times to see it no longer starts to distort slightly by multiple copies of itself being stacked on top of each other.
* Change a filter on an added layer and re-add, the layer will be removed and then re-add with new filter. E.g. Earth Resources Lite(new) -> Mineral Occurrence (Commodity filter).