### PR TITLE
Fix the problem of loading too many WMS tiles

### DIFF
--- a/projects/portal-core-ui/src/lib/service/wms/cs-wms.service.ts
+++ b/projects/portal-core-ui/src/lib/service/wms/cs-wms.service.ts
@@ -452,7 +452,8 @@ export class CsWMSService {
           wmsImagProv = new WebMapServiceImageryProvider({
             url: url,
             layers: wmsOnlineResource.name,
-            parameters: params
+            parameters: params,
+            rectangle: Rectangle.fromDegrees(lonlatextent[0], lonlatextent[1], lonlatextent[2], lonlatextent[3])
           });
         } else {
 


### PR DESCRIPTION
Fix the problem of loading too many WMS tiles by defining the surrounded rectangle