### PR TITLE
AUS-3744 Polygon filter clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auscope/portal-core-ui",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/portal-core-ui/package.json
+++ b/projects/portal-core-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auscope/portal-core-ui",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "license": "(LGPL OR Apache-2.0)",
   "repository": {
     "type": "git",

--- a/projects/portal-core-ui/src/lib/model/data/layer.model.ts
+++ b/projects/portal-core-ui/src/lib/model/data/layer.model.ts
@@ -29,7 +29,8 @@ export class LayerModel {
   stackdriverFailingHosts: string[];
   ogcFilter: String;
   wfsUrls: String[];
-  sldBody: string;
+  sldBody: string;      // SLD_BODY for 1.1.1 GetMap/GetFeatureInfo requests
+  sldBody130?: string;  // SLD_BODY FOR 1.3.0 GetMap/GetFeatureInfo requests
   clickCSWRecordsIndex: number[];
   clickPixel: any;
   clickCoord: any;

--- a/projects/portal-core-ui/src/lib/service/cesium-map/cs-map-object.ts
+++ b/projects/portal-core-ui/src/lib/service/cesium-map/cs-map-object.ts
@@ -230,6 +230,7 @@ export class CsMapObject {
         polygonStringBS.next(coordString);
         this.polygonEditable$.disable();
         this.isDrawingPolygonBS.next(false);
+        this.ignoreMapClick = false;
        }
     });
     return polygonStringBS;


### PR DESCRIPTION
* Re-enable map clicks after a polygon filter is drawn.
* Add a 1.3.0 SLD_BODY to the layer after a layer is added with a polygon filter to ensure lat/lng coordinates are swapped to lng/lat for the WMS GetFeatureInfo requests.