### PR TITLE
AUS-3930 Getmaps via the proxy now use http get

### DIFF
--- a/projects/portal-core-ui/src/lib/service/wms/cs-wms.service.ts
+++ b/projects/portal-core-ui/src/lib/service/wms/cs-wms.service.ts
@@ -521,8 +521,8 @@ export class CsWMSService {
           const res = new Resource({url: url, proxy: new MyDefaultProxy(me.env.portalBaseUrl + 'getViaProxy.do?url=')});
 
 
-          // Force Resource to use 'POST' and our proxy
-          params['usepost'] = true;
+          // Force Resource to use  our proxy and the POST method from the proxy to the origin server
+          params['usepostafterproxy'] = true;
           wmsImagProv = new WebMapServiceImageryProvider({
             url: res,
             layers: wmsOnlineResource.name,


### PR DESCRIPTION
getmaps via the proxy now use http get to enable caching.  the proxy will then POST to the origin.