### PR TITLE
AUS-3605 ArcGIS & Mineral Tenements fixes

### DIFF
--- a/projects/portal-core-ui/src/lib/service/style/wms/sld.service.ts
+++ b/projects/portal-core-ui/src/lib/service/style/wms/sld.service.ts
@@ -71,22 +71,6 @@ export class SldService {
         observer.complete();
       });
     }
-    // For ArcGIS mineral tenements layer we can get SLD_BODY parameter locally
-    if (
-      UtilitiesService.resourceIsArcGIS(onlineResource) &&
-      onlineResource.name === 'MineralTenement'
-    ) {
-      return new Observable((observer) => {
-        param.styles = 'mineralTenementStyle';
-        const sldBody = MinTenemStyleService.getSld(
-          onlineResource.name,
-          param.styles,
-          param.ccProperty
-        );
-        observer.next(sldBody);
-        observer.complete();
-      });
-    }
 
     // For GeoSciML 4.1 boreholes
     if (onlineResource.name === 'gsmlbh:Borehole') {

--- a/projects/portal-core-ui/src/lib/utility/simplexml.service.ts
+++ b/projects/portal-core-ui/src/lib/utility/simplexml.service.ts
@@ -376,6 +376,10 @@ export class SimpleXMLService {
                   name = feature.onlineResource.name;
                 }
               }
+              // QLD Mineral Tenements ArcGIS has "Null" identifier, use name instead
+              if (name == "Null") {
+                name = features[i].getAttribute('name');
+              }
               if (name.indexOf('http://') === 0) {
                 name = name.substring(name.lastIndexOf('/') + 1, name.length);
               }
@@ -399,31 +403,33 @@ export class SimpleXMLService {
           features = featureMembers[0].childNodes;
         }
       }
-      for (let featureNode of features) {
-        // VT: We will try get the name either via gml:id, gml:name or fid
-        let name = featureNode.getAttribute('gml:id');
-        if (UtilitiesService.isEmpty(name)) {
-          name = SimpleXMLService.evaluateXPath(rootNode, featureNode, 'gml:name', Constants.XPATH_STRING_TYPE).stringValue;
+      if (features) {
+        for (let featureNode of features) {
+          // VT: We will try get the name either via gml:id, gml:name or fid
+          let name = featureNode.getAttribute('gml:id');
           if (UtilitiesService.isEmpty(name)) {
-            // VT: geological province Is there a better way to do this? If this gets tiresome, we will default it to just using name
-            if (featureNode.childNodes !== undefined &&
-              featureNode.childNodes[0] !== undefined &&
-              featureNode.childNodes[0].hasOwnProperty('getAttribute')) {
-              name = featureNode.childNodes[0].getAttribute('fid');
-            }
+            name = SimpleXMLService.evaluateXPath(rootNode, featureNode, 'gml:name', Constants.XPATH_STRING_TYPE).stringValue;
             if (UtilitiesService.isEmpty(name)) {
-              name = feature.onlineResource.name + '.' + Math.floor(Math.random() * 60) + 1;
+              // VT: geological province Is there a better way to do this? If this gets tiresome, we will default it to just using name
+              if (featureNode.childNodes !== undefined &&
+                featureNode.childNodes[0] !== undefined &&
+                featureNode.childNodes[0].hasOwnProperty('getAttribute')) {
+                name = featureNode.childNodes[0].getAttribute('fid');
+              }
+              if (UtilitiesService.isEmpty(name)) {
+                name = feature.onlineResource.name + '.' + Math.floor(Math.random() * 60) + 1;
+              }
             }
           }
-        }
-        if (typeof name === 'string' && name.length > 0) {
-          docs.push({
-            key: name,
-            layer: feature.layer,
-            onlineResource: feature.onlineResource,
-            value: featureNode,
-            format: 'XML'
-          });
+          if (typeof name === 'string' && name.length > 0) {
+            docs.push({
+              key: name,
+              layer: feature.layer,
+              onlineResource: feature.onlineResource,
+              value: featureNode,
+              format: 'XML'
+            });
+          }
         }
       }
     }

--- a/projects/portal-core-ui/src/lib/utility/utilities.service.ts
+++ b/projects/portal-core-ui/src/lib/utility/utilities.service.ts
@@ -490,8 +490,9 @@ export class UtilitiesService {
      * Returns true iff (if and only if) this is an ESRI ArcGIS server
      * @param onlineResource online resource record for service
      */
-    public static resourceIsArcGIS(onlineResource: OnlineResourceModel) {
-        return (onlineResource.applicationProfile && onlineResource.applicationProfile.indexOf('Esri:ArcGIS Server') > -1);
+    public static resourceIsArcGIS(onlineResource: OnlineResourceModel): boolean {
+        return ((onlineResource?.applicationProfile.indexOf('Esri:ArcGIS Server') > -1) ||
+                        (onlineResource?.url.indexOf('arcgis') > -1));
     }
 
     /**


### PR DESCRIPTION
- Remove broken & superceded mineral tenements style sheet enabler code
- Fix "Null" identifiers for map click features
- Stop exceptions when 'features' is null e.g. "Isotopes" --> "GA Lu-Hf Isotopes: Full Analytical Data"
- Recognition of QLD ArcGIS layers